### PR TITLE
Aborting unnecessary API

### DIFF
--- a/ice.js
+++ b/ice.js
@@ -127,6 +127,15 @@ var page         = require('webpage').create();
 page.onConsoleMessage = function () {};
 page.onError  = function () {};
 
+/**
+* aborting unnecessary API
+*/
+page.onResourceRequested = function(requestData, request) {
+  if (requestData.url.match(/(getGameScore|getPlexts|getPortalDetails)/g)) {
+    request.abort();
+  }
+};
+
 /** @function setVieportSize */
 if (!iitc) {
   page.viewportSize = {


### PR DESCRIPTION
Do not run unnecessary API to reduce the load of IntelMap

May these APIs will be run at startup
`getGameScore`, `getPlexts`, `getPortalDetails`