### PR TITLE
Added picture format config option 'format'

### DIFF
--- a/ice/ingress-ice.conf.sample
+++ b/ice/ingress-ice.conf.sample
@@ -32,6 +32,8 @@ hideRes=false
 hideEnl=false
 hideLink=false
 hideField=false
+# Picture format (png/jpg)
+format=png
 
 [cookies]
 #> If set, will use cookies for authentication instead of login/password

--- a/ice/modules/ice-60-features-main.js
+++ b/ice/modules/ice-60-features-main.js
@@ -26,7 +26,11 @@
 */
 function s() {
   announce('Screen saved');
-  page.render(folder + 'ice-' + getDateTime(1) + '.png');
+  if (config.format == undefined || config.format == '') {
+      page.render(folder + 'ice-' + getDateTime(1) + '.png');
+  } else {
+      page.render(folder + 'ice-' + getDateTime(1) + '.' + config.format);
+  }
 }
 
 /**
@@ -181,7 +185,11 @@ function main() {
       addTimestamp(getDateTime(0), config.iitc);
     }
     s();
-    lastScreen = 'ice-' + getDateTime(1) + '.png';
+    if (config.format == undefined || config.format == '') {
+      lastScreen = 'ice-' + getDateTime(1) + '.png';
+    } else {
+      lastScreen = 'ice-' + getDateTime(1) + '.' + config.format;
+    }
     postprocess(lastScreen);
   }, 2000);
 }


### PR DESCRIPTION
No longer hardcode picture format to png. Use jpg or any other
picture format supported by PhantomJS.

ingress-ice is really a great tool! And I love it! But the first thing I did was replacing the picture format of png to jpg in order to save a lot of space. I often let my laptop running at home while I'm on the operation. And I write the files to my Dropbox folder for easy file sharing ...