### PR TITLE
bugfix s3upload Not doling out the file path correctly.

### DIFF
--- a/ice/modules/ice-60-core.js
+++ b/ice/modules/ice-60-core.js
@@ -151,7 +151,7 @@ function humanPresence() {
 function postprocess (file) {
   if (config.S3Key) {
     announce('Uploading to Amazon S3...');
-    uploadS3(config.S3Key, config.S3Secret, config.S3Bucket, config.S3Alc, file, config.S3Remove);
+    uploadS3(config.S3Key, config.S3Secret, config.S3Bucket, config.S3Alc, config.directory+file, config.S3Remove);
   }
 }
 


### PR DESCRIPTION
#83 
https://github.com/nibogd/ingress-ice/blob/master/ice/modules/ice-60-core.js#L151
Argument `file` == `filename` ?? method require `file path` !

Look at the
https://github.com/nibogd/ingress-ice/blob/master/ice/modules/ice-20-aws.js#L20

<img width="673" alt="2016-04-19 15 43 57" src="https://cloud.githubusercontent.com/assets/730728/14630138/95df03bc-0646-11e6-9ae7-6381372efd44.png">
