### PR TITLE
do not show portal highlight selector

### DIFF
--- a/ice/modules/ice-60-core.js
+++ b/ice/modules/ice-60-core.js
@@ -55,6 +55,7 @@ function hideDebris(iitcz) {
         if (document.querySelector('#chat'))                      {document.querySelector('#chat').style.display = 'none';}
         if (document.querySelector('#chatcontrols'))              {document.querySelector('#chatcontrols').style.display = 'none';}
         if (document.querySelector('#chatinput'))                 {document.querySelector('#chatinput').style.display = 'none';}
+        if (document.querySelector('#portal_highlight_select'))   {document.querySelector('#portal_highlight_select').style.display = 'none';}
         if (document.querySelector('#updatestatus'))              {document.querySelector('#updatestatus').style.display = 'none';}
         if (document.querySelector('#sidebartoggle'))             {document.querySelector('#sidebartoggle').style.display = 'none';}
         if (document.querySelector('#scrollwrapper'))             {document.querySelector('#scrollwrapper').style.display = 'none';}


### PR DESCRIPTION
With plugins like the [Show Portal Weakness](https://static.iitc.me/build/release/plugins/show-portal-weakness.user.js) Plugin there is a Highlight Selector in the upper left corner. That shouldn't be displayed.

### Current behaviour

![with](https://user-images.githubusercontent.com/7953011/26927522-89aa201a-4c52-11e7-9bf7-c0be678ade80.jpg)

### Behaviour after fix

![without](https://user-images.githubusercontent.com/7953011/26927535-96259496-4c52-11e7-981e-22fda9e64617.jpg)


